### PR TITLE
町田さん、林さん、栗原さんのSNSリンクを修正

### DIFF
--- a/src/app/home/special-thanks/special-thanks.component.html
+++ b/src/app/home/special-thanks/special-thanks.component.html
@@ -31,7 +31,7 @@
             <div class="special-thanks__item-links">
               <ul class="special-thanks__item-links-items">
                 <li class="special-thanks__item-links-item is-github">
-                  <a href="https://github.com/shioimm" target="_blank"><i class="fab fa-github"></i></a>
+                  <a href="https://github.com/machida" target="_blank"><i class="fab fa-github"></i></a>
                 </li>
                 <li class="special-thanks__item-links-item is-twitter">
                   <a href="https://twitter.com/machida" target="_blank"><i class="fab fa-twitter"></i></a>

--- a/src/app/home/team/team.component.html
+++ b/src/app/home/team/team.component.html
@@ -126,10 +126,10 @@
             <div class="team__item-links">
               <ul class="team__item-links-items">
                 <li class="team__item-links-item is-github">
-                  <a href="@hayashiyoshino" target="_blank"><i class="fab fa-github"></i></a>
+                  <a href="https://github.com/hayashiyoshino" target="_blank"><i class="fab fa-github"></i></a>
                 </li>
                 <li class="team__item-links-item is-twitter">
-                  <a href="https://github.com/hayashiyoshino" target="_blank"><i class="fab fa-twitter"></i></a>
+                  <a href="https://twitter.com/hayashiyoshino" target="_blank"><i class="fab fa-twitter"></i></a>
                 </li>
               </ul>
             </div>
@@ -145,10 +145,10 @@
             <div class="team__item-links">
               <ul class="team__item-links-items">
                 <li class="team__item-links-item is-github">
-                  <a href="https://twitter.com/__castagna" target="_blank"><i class="fab fa-github"></i></a>
+                  <a href="https://github.com/Y-KURI" target="_blank"><i class="fab fa-github"></i></a>
                 </li>
                 <li class="team__item-links-item is-twitter">
-                  <a href="https://github.com/Y-KURI" target="_blank"><i class="fab fa-twitter"></i></a>
+                  <a href="https://twitter.com/__castagna" target="_blank"><i class="fab fa-twitter"></i></a>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
# 概要
掲題の3名のリンクが誤ってリンクされていたので、適切なものに修正しました。