### PR TITLE
Fix meta tags

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,8 +9,8 @@
     <!-- OGP設定 -->
     <meta property="og:title" content="Tama Ruby会議01" />
     <meta property="og:type" content="activity" />
-    <meta property="og:url" content="https://tama-rb.github.io/tamarubykaigi2019/" />
-    <meta property="og:image" content="https://tama-rb.github.io/tamarubykaigi2019/" />
+    <meta property="og:url" content="https://tama-rb.github.io/tamarubykaigi01/" />
+    <meta property="og:image" content="https://tama-rb.github.io/tamarubykaigi01/" />
     <meta property="og:site_name" content="Tama Ruby会議01" />
     <meta property="og:description" content="Tama Ruby会議01 7/6 13:00-18:20 #tamarb" />
 

--- a/src/index.html
+++ b/src/index.html
@@ -10,8 +10,8 @@
     <!-- OGP設定 -->
     <meta property="og:title" content="Tama Ruby会議01" />
     <meta property="og:type" content="activity" />
-    <meta property="og:url" content="https://tama-rb.github.io/tamarubykaigi2019/" />
-    <meta property="og:image" content="https://tama-rb.github.io/tamarubykaigi2019/" />
+    <meta property="og:url" content="https://tama-rb.github.io/tamarubykaigi01/" />
+    <meta property="og:image" content="https://tama-rb.github.io/tamarubykaigi01/" />
     <meta property="og:site_name" content="Tama Ruby会議01" />
     <meta property="og:description" content="Tama Ruby会議01 7/6 13:00-18:20 #tamarb" />
 


### PR DESCRIPTION
古いURLが設定されていた箇所を修正

```
     <!-- OGP設定 -->
     <meta property="og:title" content="Tama Ruby会議01" />
     <meta property="og:type" content="activity" />
-    <meta property="og:url" content="https://tama-rb.github.io/tamarubykaigi2019/" />
-    <meta property="og:image" content="https://tama-rb.github.io/tamarubykaigi2019/" />
+    <meta property="og:url" content="https://tama-rb.github.io/tamarubykaigi01/" />
+    <meta property="og:image" content="https://tama-rb.github.io/tamarubykaigi01/" />
     <meta property="og:site_name" content="Tama Ruby会議01" />
     <meta property="og:description" content="Tama Ruby会議01 7/6 13:00-18:20 #tamarb" />
```